### PR TITLE
Add read perms to the copied artifacts

### DIFF
--- a/cmd/watcher/main.go
+++ b/cmd/watcher/main.go
@@ -79,7 +79,7 @@ func (_ FCopier) Copy(a Artifact, r io.Reader) error {
 		log.Printf("Copy: %v\n", err)
 		return err
 	}
-	err = os.Chmod(a.LocalPath, 0701)
+	err = os.Chmod(a.LocalPath, 0705)
 	if err != nil {
 		log.Printf("Copy: %v\n", err)
 		return err


### PR DESCRIPTION
- The wasm binary is fetched from the browser so requires read permissions 